### PR TITLE
Keep all rows in the phenotype harmonized table

### DIFF
--- a/primed_phenotype_inventory.wdl
+++ b/primed_phenotype_inventory.wdl
@@ -39,6 +39,6 @@ task write_primed_phenotype_inventory_table {
     >>>
 
     runtime {
-        docker: "uwgac/primed-inventory-workflows:0.1.0"
+        docker: "uwgac/primed-inventory-workflows:0.1.1"
     }
 }

--- a/write_primed_phenotype_inventory_table.R
+++ b/write_primed_phenotype_inventory_table.R
@@ -46,9 +46,7 @@ for (i in seq_along(workspaces$workspace)) {
 
   tables <- avtables(namespace=workspace_namespace, name=workspace_name)
   if (input_table_name %in% tables$table) {
-    table <- avtable(input_table_name, namespace=workspace_namespace, name=workspace_name)
-    # Keep all rows in the table for now.
-    x <- table
+    x <- avtable(input_table_name, namespace=workspace_namespace, name=workspace_name)
   }
   else {
     x = tibble()
@@ -72,17 +70,9 @@ id_column_name = quo_name(paste0(output_table_name, "_id"))
 results <- results %>%
   # We separated workspace into namespace and name, so we don't need it anymore.
   select(-workspace) %>%
-  select(
+  rename(
     # Set the id column appropriately, using the output table name.
-    !!id_column_name := phenotype_harmonized_id,
-    studies,
-    workspace_namespace,
-    workspace_name,
-    table,
-    n_rows,
-    n_subjects,
-    file_path,
-    everything(),
+    !!id_column_name := phenotype_harmonized_id
   )
 print(results)
 

--- a/write_primed_phenotype_inventory_table.R
+++ b/write_primed_phenotype_inventory_table.R
@@ -47,9 +47,8 @@ for (i in seq_along(workspaces$workspace)) {
   tables <- avtables(namespace=workspace_namespace, name=workspace_name)
   if (input_table_name %in% tables$table) {
     table <- avtable(input_table_name, namespace=workspace_namespace, name=workspace_name)
-    x <- table %>%
-      # phenotype_harmonized_id is needed to make the table unique.
-      select(phenotype_harmonized_id, table=domain, n_subjects, n_rows, file_path)
+    # Keep all rows in the table for now.
+    x <- table
   }
   else {
     x = tibble()
@@ -85,6 +84,7 @@ results <- results %>%
     file_path,
     everything(),
   )
+print(results)
 
 # Delete the table before writing the new data, if it already exists.
 tables <- avtables(namespace=output_workspace_namespace, name=output_workspace_name)


### PR DESCRIPTION
This will retain rows like data_model_version and qc_report, if they exist.