### PR TITLE
Create unique entity ids by appending workspace name to the existing dataset id

### DIFF
--- a/primed_ancestry_analysis_inventory.wdl
+++ b/primed_ancestry_analysis_inventory.wdl
@@ -39,6 +39,6 @@ task write_primed_ancestry_analysis_inventory_table {
     >>>
 
     runtime {
-        docker: "uwgac/primed-inventory-workflows:0.3.0"
+        docker: "uwgac/primed-inventory-workflows:0.3.2"
     }
 }

--- a/primed_association_analysis_inventory.wdl
+++ b/primed_association_analysis_inventory.wdl
@@ -39,6 +39,6 @@ task write_primed_association_analysis_inventory_table {
     >>>
 
     runtime {
-        docker: "uwgac/primed-inventory-workflows:0.3.1"
+        docker: "uwgac/primed-inventory-workflows:0.3.2"
     }
 }

--- a/primed_genotype_inventory.wdl
+++ b/primed_genotype_inventory.wdl
@@ -39,6 +39,6 @@ task write_primed_genotype_inventory_table {
     >>>
 
     runtime {
-        docker: "uwgac/primed-inventory-workflows:0.3.1"
+        docker: "uwgac/primed-inventory-workflows:0.3.2"
     }
 }

--- a/primed_phenotype_inventory.wdl
+++ b/primed_phenotype_inventory.wdl
@@ -39,6 +39,6 @@ task write_primed_phenotype_inventory_table {
     >>>
 
     runtime {
-        docker: "uwgac/primed-inventory-workflows:0.1.1"
+        docker: "uwgac/primed-inventory-workflows:0.3.2"
     }
 }

--- a/write_primed_ancestry_analysis_inventory_table.R
+++ b/write_primed_ancestry_analysis_inventory_table.R
@@ -90,8 +90,9 @@ output_table_name = argv$output_table_name
 
 id_column_name = quo_name(paste0(output_table_name, "_id"))
 results <- results %>%
-  select(ancestry_analysis_id, everything()) %>%
-  rename(!!id_column_name := ancestry_analysis_id) %>%
+  rename(id_in_table = ancestry_analysis_id) %>%
+  mutate(!!id_column_name := paste(workspace_name, "_", id_in_table, sep="")) %>%
+  select(!!id_column_name, everything()) %>%
   # We separated workspace into namespace and name, so we don't need it anymore.
   select(-workspace)
 print(results)

--- a/write_primed_association_analysis_inventory_table.R
+++ b/write_primed_association_analysis_inventory_table.R
@@ -94,8 +94,9 @@ output_table_name = argv$output_table_name
 
 id_column_name = quo_name(paste0(output_table_name, "_id"))
 results <- results %>%
-  select(association_analysis_id, everything()) %>%
-  rename(!!id_column_name := association_analysis_id) %>%
+  rename(id_in_table = association_analysis_id) %>%
+  mutate(!!id_column_name := paste(workspace_name, "_", id_in_table, sep="")) %>%
+  select(!!id_column_name, everything()) %>%
   # We separated workspace into namespace and name, so we don't need it anymore.
   select(-workspace)
 print(results)

--- a/write_primed_genotype_inventory_table.R
+++ b/write_primed_genotype_inventory_table.R
@@ -97,8 +97,9 @@ output_table_name = argv$output_table_name
 
 id_column_name = quo_name(paste0(output_table_name, "_id"))
 results <- results %>%
-  select(dataset_id, everything()) %>%
-  rename(!!id_column_name := dataset_id) %>%
+  rename(id_in_table = dataset_id) %>%
+  mutate(!!id_column_name := paste(workspace_name, "_", id_in_table, sep="")) %>%
+  select(!!id_column_name, everything()) %>%
   # We separated workspace into namespace and name, so we don't need it anymore.
   select(-workspace)
 print(results)

--- a/write_primed_phenotype_inventory_table.R
+++ b/write_primed_phenotype_inventory_table.R
@@ -38,6 +38,7 @@ print(workspaces)
 # Loop over workspaces and pull the phenotype inventory information.
 results_list <- list()
 for (i in seq_along(workspaces$workspace)) {
+  print(paste("Processing workspace:", workspaces$workspace[i]))
   input_table_name <- "phenotype_harmonized"
 
   workspace = workspaces$workspace[i]

--- a/write_primed_phenotype_inventory_table.R
+++ b/write_primed_phenotype_inventory_table.R
@@ -72,7 +72,7 @@ results <- results %>%
   select(-workspace) %>%
   rename(id_in_table = phenotype_harmonized_id) %>%
   mutate(!!id_column_name := paste(workspace_name, "_", id_in_table, sep="")) %>%
-  select(!!id_column_name, everything()) %>%
+  select(!!id_column_name, everything())
 print(results)
 
 # Delete the table before writing the new data, if it already exists.

--- a/write_primed_phenotype_inventory_table.R
+++ b/write_primed_phenotype_inventory_table.R
@@ -70,10 +70,9 @@ id_column_name = quo_name(paste0(output_table_name, "_id"))
 results <- results %>%
   # We separated workspace into namespace and name, so we don't need it anymore.
   select(-workspace) %>%
-  rename(
-    # Set the id column appropriately, using the output table name.
-    !!id_column_name := phenotype_harmonized_id
-  )
+  rename(id_in_table = phenotype_harmonized_id) %>%
+  mutate(!!id_column_name := paste(workspace_name, "_", id_in_table, sep="")) %>%
+  select(!!id_column_name, everything()) %>%
 print(results)
 
 # Delete the table before writing the new data, if it already exists.


### PR DESCRIPTION
We've run into trouble a couple times now by assuming that the various dataset_ids are unique across workspaces. An easier fix is to append the workspace name to the dataset_ids, which creates definitely unique ids for use in the inventory tables.

Update all R scripts that write the tables to use this new id scheme.